### PR TITLE
Add --cpu-torch flag to lazyqsar setup (pivot from PR #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can install optional extras depending on your use case:
 | `descriptors` | `pip install -e .[descriptors]` | Built-in molecular descriptors (RDKit, FPSim2, deep-learning models) |
 | `all` | `pip install -e .[all]` | Everything above |
 
-> Since v3.3.0, the `descriptors` extra installs the CPU-only PyTorch wheel by default on Linux, macOS arm64, and Windows — no `--index-url` workaround needed.
+> CPU-only deployments where pip would otherwise pull the CUDA torch wheel (~3 GB) can pass `--cpu-torch` to force-reinstall torch from PyTorch's CPU index: `lazyqsar setup --descriptors --cpu-torch`.
 
 The first time you use deep-learning descriptors (Chemeleon, CLAMP, CDDD), their checkpoints are downloaded automatically. To do this in advance:
 

--- a/lazyqsar/cli/main.py
+++ b/lazyqsar/cli/main.py
@@ -35,8 +35,12 @@ def _cmd_setup(args):
         sys.exit(1)
 
     if not args.descriptors:
-        for flag, name in [(args.only, "--only"), (args.target_dir, "--target-dir")]:
-            if flag is not None:
+        for flag, name in [
+            (args.only, "--only"),
+            (args.target_dir, "--target-dir"),
+            (args.cpu_torch, "--cpu-torch"),
+        ]:
+            if flag:
                 print(
                     f"Warning: {name} has no effect without --descriptors.",
                     file=sys.stderr,
@@ -77,6 +81,7 @@ def _setup_fit():
 def _setup_descriptors(args):
     from ..utils.setup import (
         install_torch,
+        install_cpu_torch_force,
         install_chemprop,
         install_rdkit,
         install_fpsim2,
@@ -99,7 +104,10 @@ def _setup_descriptors(args):
         )
         sys.exit(1)
 
-    install_torch()
+    if args.cpu_torch:
+        install_cpu_torch_force()
+    else:
+        install_torch()
     install_chemprop()
     install_rdkit()
     install_fpsim2()
@@ -196,6 +204,11 @@ def main():
         default=None,
         metavar="DIR",
         help="Directory to download checkpoints into (default: ~/.lazyqsar/). Only meaningful with --descriptors.",
+    )
+    p_setup.add_argument(
+        "--cpu-torch",
+        action="store_true",
+        help="Force-reinstall torch from PyTorch's CPU index, replacing any CUDA wheel pip may have installed via PyPI. Only meaningful with --descriptors.",
     )
 
     # --- fit ---

--- a/lazyqsar/utils/setup.py
+++ b/lazyqsar/utils/setup.py
@@ -61,6 +61,24 @@ def install_torch():
     )
 
 
+def install_cpu_torch_force():
+    logger.info("Force-reinstalling PyTorch as CPU (replacing any CUDA wheel)...")
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--upgrade",
+            "--force-reinstall",
+            "torch==2.6.0",
+            "--index-url",
+            "https://download.pytorch.org/whl/cpu",
+        ]
+    )
+
+
 def install_chemprop():
     logger.info("Installing chemprop...")
     subprocess.check_call(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,31 +46,7 @@ fit = [
 descriptors = [
     "rdkit==2025.9.1",
     "FPSim2==0.7.3",
-
-    # CPU torch 2.6.0 wheels, one per (Python x platform).
-    # Linux x86_64
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp310-cp310-linux_x86_64.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl ; python_version == '3.11' and sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl ; python_version == '3.12' and sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl ; python_version == '3.13' and sys_platform == 'linux' and platform_machine == 'x86_64'",
-    # Linux aarch64
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl ; python_version == '3.11' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl ; python_version == '3.12' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl ; python_version == '3.13' and sys_platform == 'linux' and platform_machine == 'aarch64'",
-    # macOS arm64 (Apple Silicon)
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0-cp310-none-macosx_11_0_arm64.whl ; python_version == '3.10' and sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0-cp311-none-macosx_11_0_arm64.whl ; python_version == '3.11' and sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl ; python_version == '3.12' and sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl ; python_version == '3.13' and sys_platform == 'darwin' and platform_machine == 'arm64'",
-    # Windows x86_64
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'AMD64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-win_amd64.whl ; python_version == '3.11' and sys_platform == 'win32' and platform_machine == 'AMD64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl ; python_version == '3.12' and sys_platform == 'win32' and platform_machine == 'AMD64'",
-    "torch @ https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl ; python_version == '3.13' and sys_platform == 'win32' and platform_machine == 'AMD64'",
-    # Fallback (e.g. macOS x86_64, where no PyTorch 2.6.0 wheel exists).
-    "torch>=2.6.0 ; python_version not in '3.10 3.11 3.12 3.13' or ((sys_platform != 'linux' or platform_machine not in 'x86_64 aarch64') and (sys_platform != 'darwin' or platform_machine != 'arm64') and (sys_platform != 'win32' or platform_machine != 'AMD64'))",
-
+    "torch>=2.6.0",
     "chemprop==2.2.3",
     "chemeleon==0.1.3",
     "jinja2==3.1.4",


### PR DESCRIPTION
## Summary

- Revert pyproject.toml's `[descriptors]` extra to the plain `torch>=2.6.0` constraint (16 direct-URL specs removed).
- Add `--cpu-torch` flag to `lazyqsar setup`. When passed alongside `--descriptors`, it runs `pip install --upgrade --force-reinstall torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu`, swapping any pre-existing CUDA torch wheel for a CPU one.
- Keep `version = "3.3.0"`.

## Why

PR #37 (merged earlier today) tried to pin the CPU torch wheel via PEP 440 direct-URL specs in pyproject.toml. The pyproject change worked locally and parsed cleanly, but the PyPI publish workflow on the v3.3.0 release tag failed with:

```
HTTP 400 Can't have direct dependency: torch @ https://download.pytorch.org/whl/cpu/...
See https://packaging.python.org/specifications/core-metadata
```

PyPI's metadata validator rejects any direct-URL dep in published packages — this is policy across the whole index. The v3.3.0 GitHub release + tag were deleted to clear the way for the new approach.

This PR keeps the user-visible goal (CPU torch by default in Hub deployments) but moves the implementation from "install-time resolution" to "post-install force-reinstall," which is a pattern PyPI happily accepts.

## Consumer migration

`chembl-antimicrobial-hub-incorporation` install.yml goes from:

```yaml
- ["pip", "torch", "2.6.0", "--index-url", "https://download.pytorch.org/whl/cpu"]
- "pip install lazyqsar[descriptors]@git+https://github.com/ersilia-os/lazy-qsar.git@v3.2.2"
- "lazyqsar setup --descriptors --only ... --target-dir ..."
```

to:

```yaml
- ["pip", "lazyqsar[descriptors]", "3.3.0"]
- "lazyqsar setup --descriptors --cpu-torch --only ... --target-dir ..."
```

One fewer line, and lazyqsar is now pinned by version rather than by git commit.

## After merge

Cut `v3.3.0` fresh from main:

```bash
gh release create v3.3.0 --repo ersilia-os/lazy-qsar --title "v3.3.0 — --cpu-torch flag" --generate-notes
```

(The previous v3.3.0 release/tag were deleted.)

## Test plan

- [x] `python -m lazyqsar.cli.main setup --help` shows the new `--cpu-torch` flag with help text.
- [x] pyproject.toml parses with poetry-core (no direct-URL deps).
- [ ] Reviewer: confirm publish workflow succeeds on the new v3.3.0 tag.
- [ ] In a Linux x86_64 venv: pre-install CUDA torch, then `lazyqsar setup --descriptors --cpu-torch` → verify torch becomes `2.6.0+cpu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)