### PR TITLE
Fix memory accumulation in LazyQSAR prediction pipeline 

### DIFF
--- a/dev/tests/test_cache.py
+++ b/dev/tests/test_cache.py
@@ -1,0 +1,174 @@
+"""
+Tests for bounded cache behavior in LazyClassifierQSAR and ArtifactWrapper.
+
+These tests use mode="fast" (Morgan fingerprints only) so they run without
+DL model checkpoints. They verify that the caches do NOT grow with the
+number of distinct SMILES batches seen.
+"""
+
+import pytest
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+SMILES_TRAIN = [
+    "CCO",
+    "CCN",
+    "CCC",
+    "c1ccccc1",
+    "CC(=O)O",
+    "CC(=O)N",
+    "c1ccncc1",
+    "CC#N",
+    "CCCO",
+    "CCCN",
+    "CC(C)O",
+    "CC(C)N",
+    "c1ccc(O)cc1",
+    "c1ccc(N)cc1",
+    "CC(=O)c1ccccc1",
+    "CCOC(=O)C",
+    "CCc1ccccc1",
+    "c1ccc(CC)cc1",
+    "CCCC",
+    "CCCCO",
+]
+Y_TRAIN = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+
+
+def _distinct_batches(n: int = 10, size: int = 5):
+    """Return n distinct SMILES batches of `size` molecules each."""
+    base = ["CC" + "O" * (i + 1) for i in range(n * size)]
+    return [base[i * size : (i + 1) * size] for i in range(n)]
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def trained_qsar(tmp_path_factory):
+    """Fit a LazyClassifierQSAR(mode='fast') on a tiny synthetic dataset."""
+    from lazyqsar.qsar import LazyClassifierQSAR
+
+    tmp = tmp_path_factory.mktemp("model")
+    m = LazyClassifierQSAR(mode="fast")
+    m.fit(smiles_list=SMILES_TRAIN, y=Y_TRAIN)
+    m.save_onnx(str(tmp))
+    return m, str(tmp)
+
+
+@pytest.fixture(scope="module")
+def artifact_wrapper(trained_qsar):
+    """Load an ArtifactWrapper from the saved ONNX model."""
+    from lazyqsar.qsar import LazyClassifierQSAR
+
+    _, model_dir = trained_qsar
+    return LazyClassifierQSAR.load_onnx(model_dir)
+
+
+# ── ArtifactWrapper cache tests ───────────────────────────────────────────────
+
+
+class TestArtifactWrapperCache:
+    def test_cache_does_not_grow_unbounded(self, artifact_wrapper):
+        """Calling predict_proba on N distinct batches must not accumulate N cache entries."""
+        batches = _distinct_batches(n=20)
+        for batch in batches:
+            artifact_wrapper.predict_proba(batch)
+        # single-entry cache: only the last key/value should be set
+        assert artifact_wrapper._last_ensemble_key is not None
+        assert artifact_wrapper._last_ensemble_value is not None
+        # Crucially, there must be no unbounded dict holding old entries:
+        assert not hasattr(artifact_wrapper, "_ensemble_cache"), (
+            "_ensemble_cache dict must be removed; use _last_ensemble_key/value"
+        )
+
+    def test_same_batch_hits_cache(self, artifact_wrapper):
+        """Two predict_* calls on identical SMILES must reuse the cached ensemble."""
+        from unittest.mock import patch
+
+        from lazyqsar import qsar as qsar_mod
+
+        smi = ["CCO", "CCCO", "c1ccccc1"]
+        artifact_wrapper.predict_proba(smi)  # populates cache
+
+        hit_count = {"n": 0}
+        original_build = qsar_mod._build_weight_matrix
+
+        def counting_build(*args, **kwargs):
+            hit_count["n"] += 1
+            return original_build(*args, **kwargs)
+
+        with patch.object(qsar_mod, "_build_weight_matrix", side_effect=counting_build):
+            artifact_wrapper.predict_rank(smi)  # should NOT call _build_weight_matrix
+
+        assert hit_count["n"] == 0, (
+            "predict_rank on the same SMILES should reuse the cached ensemble, "
+            "not recompute _build_weight_matrix"
+        )
+
+    def test_different_batch_evicts_cache(self, artifact_wrapper):
+        """A distinct SMILES list must replace the cached entry, not append."""
+        smi_a = ["CCO", "CCN"]
+        smi_b = ["CCCO", "CCCN"]
+        artifact_wrapper.predict_proba(smi_a)
+        key_after_a = artifact_wrapper._last_ensemble_key
+        artifact_wrapper.predict_proba(smi_b)
+        key_after_b = artifact_wrapper._last_ensemble_key
+        assert key_after_a != key_after_b
+
+    def test_clear_cache_releases_memory(self, artifact_wrapper):
+        """clear_cache() must reset both key and value to None."""
+        artifact_wrapper.predict_proba(["CCO", "CCN"])
+        assert artifact_wrapper._last_ensemble_key is not None
+        artifact_wrapper.clear_cache()
+        assert artifact_wrapper._last_ensemble_key is None
+        assert artifact_wrapper._last_ensemble_value is None
+
+
+# ── LazyClassifierQSAR cache tests ───────────────────────────────────────────
+
+
+class TestLazyClassifierQSARCache:
+    def test_feature_cache_bounded(self, trained_qsar):
+        """_feature_cache must hold at most one entry per descriptor index."""
+        m, _ = trained_qsar
+        batches = _distinct_batches(n=30)
+        for batch in batches:
+            m.predict_proba(batch)
+        n_descriptors = len(m.descriptor_types)
+        assert len(m._feature_cache) <= n_descriptors, (
+            f"_feature_cache must have at most {n_descriptors} entries (one per descriptor), "
+            f"got {len(m._feature_cache)}"
+        )
+
+    def test_ensemble_cache_bounded(self, trained_qsar):
+        """_last_ensemble_key/value must hold a single entry, not accumulate."""
+        m, _ = trained_qsar
+        batches = _distinct_batches(n=30)
+        for batch in batches:
+            m.predict_proba(batch)
+        assert not hasattr(m, "_ensemble_cache"), (
+            "_ensemble_cache dict must not exist; use _last_ensemble_key/value"
+        )
+        assert m._last_ensemble_key is not None
+
+    def test_clear_cache(self, trained_qsar):
+        m, _ = trained_qsar
+        m.predict_proba(["CCO", "CCN"])
+        m.clear_cache()
+        assert m._last_ensemble_key is None
+        assert m._last_ensemble_value is None
+        assert len(m._feature_cache) == 0
+
+    def test_fit_clears_caches(self, tmp_path):
+        """Re-fitting must reset all cached state."""
+        from lazyqsar.qsar import LazyClassifierQSAR
+
+        m = LazyClassifierQSAR(mode="fast")
+        m.fit(smiles_list=SMILES_TRAIN, y=Y_TRAIN)
+        m.predict_proba(["CCO", "CCN"])
+        assert m._last_ensemble_key is not None
+        # fit again should reset
+        m.fit(smiles_list=SMILES_TRAIN, y=Y_TRAIN)
+        assert m._last_ensemble_key is None
+        assert len(m._feature_cache) == 0

--- a/lazyqsar/api/classifier_predict.py
+++ b/lazyqsar/api/classifier_predict.py
@@ -32,7 +32,7 @@ def _new_progress() -> Progress:
 
 def _get_chunk_size() -> int:
     try:
-        v = int(os.environ.get("LAZYQSAR_PREDICT_CHUNK", "1000"))
+        v = int(os.environ.get("LAZYQSAR_PREDICT_CHUNK", "200"))
         return v if v > 0 else 1000
     except ValueError:
         return 1000
@@ -101,17 +101,20 @@ def _predict_from_persisted(
     del X_mm
     return np.concatenate(parts) if len(parts) > 1 else parts[0]
 
+
 _PREDICT_DISPATCH = {
-    "proba":  lambda model, X: model.predict_proba(X)[:, 1],
-    "rank":   lambda model, X: model.predict_rank(X)[:, 1],
-    "logit":  lambda model, X: model.predict_logit(X)[:, 1],
-    "lift":   lambda model, X: model.predict_lift(X)[:, 1],
-    "score":  lambda model, X: model.predict_score(X)[:, 1],
+    "proba": lambda model, X: model.predict_proba(X)[:, 1],
+    "rank": lambda model, X: model.predict_rank(X)[:, 1],
+    "logit": lambda model, X: model.predict_logit(X)[:, 1],
+    "lift": lambda model, X: model.predict_lift(X)[:, 1],
+    "score": lambda model, X: model.predict_score(X)[:, 1],
     "binary": lambda model, X: model.predict(X),
 }
 
 
-def prepare_files(smiles_list, models: list = None, path: str = None, predict_type: str = "proba"):
+def prepare_files(
+    smiles_list, models: list = None, path: str = None, predict_type: str = "proba"
+):
     if path is None:
         path = tempfile.mkdtemp()
     input_csv = os.path.join(path, "_input.csv")
@@ -220,12 +223,14 @@ def _predict_from_dict(
     if not col_map:
         raise ValueError("No valid models found.")
 
-    all_featurizers = sorted({
-        dn
-        for p in col_map
-        for dn in os.listdir(p)
-        if os.path.isdir(os.path.join(p, dn))
-    })
+    all_featurizers = sorted(
+        {
+            dn
+            for p in col_map
+            for dn in os.listdir(p)
+            if os.path.isdir(os.path.join(p, dn))
+        }
+    )
     logger.info(f"Featurizers found: {all_featurizers}")
 
     _predict_fn = _PREDICT_DISPATCH[predict_type]
@@ -247,7 +252,8 @@ def _predict_from_dict(
                 continue
 
             cols_with_models = [
-                (p, c) for p, c in col_map.items()
+                (p, c)
+                for p, c in col_map.items()
                 if os.path.isdir(os.path.join(p, featurizer_name))
             ]
             if not cols_with_models:
@@ -261,8 +267,12 @@ def _predict_from_dict(
                     f"[{featurizer_name}] descriptors", total=n_chunks
                 )
                 _persist_descriptors(
-                    featurizer, smiles_list, x_path, chunk_size,
-                    progress=progress, task_id=desc_task,
+                    featurizer,
+                    smiles_list,
+                    x_path,
+                    chunk_size,
+                    progress=progress,
+                    task_id=desc_task,
                 )
                 del featurizer
                 gc.collect()
@@ -310,7 +320,9 @@ def predict(
     smiles: list = None,
 ) -> tuple[np.ndarray, list[str]]:
     if isinstance(model_dir, dict):
-        return _predict_from_dict(model_dir, input_csv, output_csv, models_txt, predict_type, smiles)
+        return _predict_from_dict(
+            model_dir, input_csv, output_csv, models_txt, predict_type, smiles
+        )
 
     if predict_type not in _PREDICT_DISPATCH:
         raise ValueError(
@@ -357,7 +369,8 @@ def predict(
     try:
         for featurizer_name in featurizers:
             tasks_with_models = [
-                t for t in tasks
+                t
+                for t in tasks
                 if os.path.isdir(os.path.join(model_dir, t, featurizer_name))
             ]
             if not tasks_with_models:
@@ -372,8 +385,12 @@ def predict(
                     f"[{featurizer_name}] descriptors", total=n_chunks
                 )
                 _persist_descriptors(
-                    featurizer, smiles_list, x_path, chunk_size,
-                    progress=progress, task_id=desc_task,
+                    featurizer,
+                    smiles_list,
+                    x_path,
+                    chunk_size,
+                    progress=progress,
+                    task_id=desc_task,
                 )
                 del featurizer
                 gc.collect()

--- a/lazyqsar/qsar.py
+++ b/lazyqsar/qsar.py
@@ -157,12 +157,21 @@ class ArtifactWrapper(object):
         self.rank_error_curves = rank_error_curves  # list[(r_knots, e_knots)|None]
         self.population_prior = population_prior
         self.descriptor_types = descriptor_types  # list[str] or None
-        self._ensemble_cache = {}
+        # Single-entry cache: reuse ensemble for repeated predict_* calls on the
+        # same smiles_list (e.g., predict_proba then predict_rank). Does not
+        # accumulate across distinct batches.
+        self._last_ensemble_key: str | None = None
+        self._last_ensemble_value: tuple | None = None
+
+    def clear_cache(self) -> None:
+        """Release cached ensemble outputs. Call between large batch jobs to reclaim RAM."""
+        self._last_ensemble_key = None
+        self._last_ensemble_value = None
 
     def _compute_ensemble(self, smiles_list):
         cache_key = _smiles_md5(smiles_list)
-        if cache_key in self._ensemble_cache:
-            return self._ensemble_cache[cache_key]
+        if cache_key == self._last_ensemble_key:
+            return self._last_ensemble_value
 
         validate_smiles(smiles_list)
 
@@ -247,7 +256,8 @@ class ArtifactWrapper(object):
             R = np.full((B, D), 0.5, dtype=np.float64)
 
         result = (W, Y, R, S, active_indices)
-        self._ensemble_cache[cache_key] = result
+        self._last_ensemble_key = cache_key
+        self._last_ensemble_value = result
         return result
 
     def predict_proba(self, smiles_list):
@@ -323,21 +333,33 @@ class LazyClassifierQSAR(object):
         self.descriptor_types = DESCRIPTORS_MODE[mode]
         self.descriptors = []  # populated in fit() after applicability check
         self.is_saved = False
-        self._feature_cache = {}
-        self._ensemble_cache = {}
+        # Per-descriptor single-entry feature cache: (last_hash, last_X) per descriptor index.
+        # Avoids recomputing expensive DL descriptors when multiple predict_* methods are
+        # called on the same smiles_list. Does not accumulate across distinct batches.
+        self._feature_cache: dict[int, tuple[str, np.ndarray]] = {}
+        # Single-entry ensemble cache: same rationale as ArtifactWrapper.
+        self._last_ensemble_key: str | None = None
+        self._last_ensemble_value: tuple | None = None
 
     def _smiles_hash(self, smiles_list):
         return _smiles_md5(smiles_list)
 
+    def clear_cache(self) -> None:
+        """Release all cached features and ensemble outputs."""
+        self._feature_cache.clear()
+        self._last_ensemble_key = None
+        self._last_ensemble_value = None
+
     def _transform_cached(self, i, smiles_list):
-        key = (i, self._smiles_hash(smiles_list))
-        if key not in self._feature_cache:
-            self._feature_cache[key] = self.descriptors[i].transform(smiles_list)
-        else:
+        h = self._smiles_hash(smiles_list)
+        if i in self._feature_cache and self._feature_cache[i][0] == h:
             logger.debug(
                 f"Using cached features for descriptor: {self.descriptor_types[i]}"
             )
-        return self._feature_cache[key]
+            return self._feature_cache[i][1]
+        X = self.descriptors[i].transform(smiles_list)
+        self._feature_cache[i] = (h, X)
+        return X
 
     def fit(self, smiles_list, y):
         import time
@@ -346,8 +368,7 @@ class LazyClassifierQSAR(object):
         from .descriptors.portfolio import DescriptorPortfolio
 
         # Clear any cached state from a previous fit.
-        self._feature_cache.clear()
-        self._ensemble_cache.clear()
+        self.clear_cache()
 
         y = np.array(y, dtype=int)
         validate_smiles(smiles_list)
@@ -366,7 +387,7 @@ class LazyClassifierQSAR(object):
         smiles_hash = self._smiles_hash(smiles_list)
         for i, (_, _, X, _) in enumerate(applicable):
             if X is not None:
-                self._feature_cache[(i, smiles_hash)] = X
+                self._feature_cache[i] = (smiles_hash, X)
 
         logger.rule("LazyClassifierQSAR")
         logger.info(
@@ -474,8 +495,8 @@ class LazyClassifierQSAR(object):
     def _compute_ensemble(self, smiles_list):
         """Compute (W, Y, R, S, active_indices) for smiles_list, cached by SMILES hash."""
         cache_key = self._smiles_hash(smiles_list)
-        if cache_key in self._ensemble_cache:
-            return self._ensemble_cache[cache_key]
+        if cache_key == self._last_ensemble_key:
+            return self._last_ensemble_value
 
         validate_smiles(smiles_list)
 
@@ -561,7 +582,8 @@ class LazyClassifierQSAR(object):
             R = np.full((B, D), 0.5, dtype=np.float64)
 
         result = (W, Y, R, S, active_indices)
-        self._ensemble_cache[cache_key] = result
+        self._last_ensemble_key = cache_key
+        self._last_ensemble_value = result
         return result
 
     def predict_proba(self, smiles_list):
@@ -682,7 +704,9 @@ class LazyClassifierQSAR(object):
                 _p_clip = float(np.clip(_avg_p, 1e-7, 1.0 - 1e-7))
                 meta["decision_cutoff_logit"] = float(np.log(_p_clip / (1.0 - _p_clip)))
                 _prior = meta.get("population_prior") or 0
-                meta["decision_cutoff_lift"] = float(_avg_p / _prior) if _prior > 0 else None
+                meta["decision_cutoff_lift"] = (
+                    float(_avg_p / _prior) if _prior > 0 else None
+                )
             else:
                 meta["decision_cutoff_logit"] = None
                 meta["decision_cutoff_lift"] = None


### PR DESCRIPTION
## Fixes #[1871](https://github.com/ersilia-os/ersilia/issues/1871)

## Summary

Fixes memory growth observed when running LazyQSAR models through Ersilia.

## Problem
`_ensemble_cache` and `_feature_cache` in `LazyClassifierQSAR` and `ArtifactWrapper` used unbounded dicts keyed by SMILES hash. With large or diverse batch workloads (e.g. eos21dr processing ~2000 compounds across many batches), these dicts grow without bound, eventually exhausting available memory and causing HTTP 500 / server crash (#1871).

## Changes
- Replaced `_ensemble_cache: dict` with a single-entry  `_last_ensemble_key / _last_ensemble_value` pattern in both 
  `ArtifactWrapper` and `LazyClassifierQSAR`. Distinct batches evict the previous entry rather than accumulating.
- Replaced `_feature_cache: dict[(int, hash), ndarray]` with `dict[int, tuple[hash, ndarray]]` — one entry per descriptor index,evicted on SMILES change. Prevents descriptor array accumulation across batches.
- Added `clear_cache()` methods to both classes for explicit memory release between large batch jobs.
- Reduced default `LAZYQSAR_PREDICT_CHUNK` from 1000 → 200 to limit peak per-chunk memory regardless of cache     behavior.
- Added `dev/tests/test_cache.py` with bounded-growth and cache-eviction regression tests.

## What this does NOT include
- Cleanup of temporary on-disk prediction artifacts (separate issue).
- A reproduction test at 1000+ compound scale (tests use small synthetic batches for CI speed; manual repro confirmed locally).



