### PR TITLE
Download all CDDD checkpoints at setup time

### DIFF
--- a/lazyqsar/descriptors/cddd.py
+++ b/lazyqsar/descriptors/cddd.py
@@ -13,10 +13,16 @@ from rdkit.Chem import Descriptors
 from rdkit import RDLogger
 from rdkit import __version__ as rdkit_version
 
-from pathlib import Path
 from urllib.request import urlretrieve
 
 from ..utils.logging import logger
+from ..utils.checkpoints import (
+    CHECKPOINT_DIR,
+    CDDD_CHECKPOINTS,
+    CDDD_ENCODER_FILENAME,
+    CDDD_FPSIM_FILENAME,
+    CDDD_SMILES_FILENAME,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -42,9 +48,9 @@ class ChemblNearestNeighbour(object):
         from FPSim2 import FPSim2Engine
 
         self.similarity_threshold = similarity_threshold
-        ckpt_dir = Path().home() / ".lazyqsar"
+        ckpt_dir = CHECKPOINT_DIR
         ckpt_dir.mkdir(exist_ok=True)
-        cddd_fpsim_path = ckpt_dir / "cddd_encoder_fpsim.h5"
+        cddd_fpsim_path = ckpt_dir / CDDD_FPSIM_FILENAME
         self.fp_database = cddd_fpsim_path
         self.fpe = FPSim2Engine(self.fp_database)
 
@@ -57,8 +63,8 @@ class ChemblNearestNeighbour(object):
 
 
 def load_smiles_indexed():
-    ckpt_dir = Path().home() / ".lazyqsar"
-    cddd_encoder_smiles = ckpt_dir / "cddd_encoder_smiles.csv"
+    ckpt_dir = CHECKPOINT_DIR
+    cddd_encoder_smiles = ckpt_dir / CDDD_SMILES_FILENAME
     smiles_indexed = []
     with open(cddd_encoder_smiles, "r") as f:
         reader = csv.reader(f)
@@ -343,38 +349,20 @@ class InferenceModel:
         """Initialize the inference model."""
         self.hparams = HParams()
 
-        ckpt_dir = Path().home() / ".lazyqsar"
+        ckpt_dir = CHECKPOINT_DIR
         ckpt_dir.mkdir(exist_ok=True)
-        cddd_path = ckpt_dir / "cddd_encoder.onnx"
-        if not cddd_path.exists():
-            logger.info(
-                "Downloading CDDD encoder model into ~/.lazyqsar/cddd_encoder.onnx"
-            )
-            urlretrieve(
-                r"https://zenodo.org/records/14811055/files/encoder.onnx?download=1",
-                cddd_path,
-            )
 
-        cddd_fpsim_path = ckpt_dir / "cddd_encoder_fpsim.h5"
-        if not cddd_fpsim_path.exists():
-            logger.info(
-                "Downloading CDDD encoder fpsim file into ~/.lazyqsar/cddd_encoder_fpsim.h5"
-            )
-            urlretrieve(
-                r"https://ersilia-models.s3.eu-central-1.amazonaws.com/eos4rw4/model/checkpoints/fpsim2_database_chembl.h5",
-                cddd_fpsim_path,
-            )
+        # Lazy fallback: fetch any CDDD checkpoint still missing. Normally these
+        # are pre-downloaded by ``lazyqsar setup --descriptors`` so nothing is
+        # fetched here — which is what keeps prediction working on air-gapped
+        # nodes. The URLs/filenames are centralized in utils/checkpoints.py.
+        for url, filename in CDDD_CHECKPOINTS:
+            dest = ckpt_dir / filename
+            if not dest.exists():
+                logger.info(f"Downloading CDDD checkpoint into ~/.lazyqsar/{filename}")
+                urlretrieve(url, dest)
 
-        cddd_smiles_path = ckpt_dir / "cddd_encoder_smiles.csv"
-        if not cddd_smiles_path.exists():
-            logger.info(
-                "Downloading CDDD encoder smiles file into ~/.lazyqsar/cddd_encoder_smiles.csv"
-            )
-            urlretrieve(
-                r"https://ersilia-models.s3.eu-central-1.amazonaws.com/eos4rw4/model/checkpoints/fpsim2_database_chembl_smiles.csv",
-                cddd_smiles_path,
-            )
-
+        cddd_path = ckpt_dir / CDDD_ENCODER_FILENAME
         encoder_path = str(cddd_path)
         if not os.path.exists(encoder_path):
             raise FileNotFoundError(

--- a/lazyqsar/utils/checkpoints.py
+++ b/lazyqsar/utils/checkpoints.py
@@ -1,0 +1,44 @@
+"""Checkpoint locations for the CDDD descriptor.
+
+Single source of truth for the download URLs and local filenames of the CDDD
+checkpoints. Both the eager ``lazyqsar setup --descriptors`` step
+(``lazyqsar/utils/setup.py``) and the lazy loader in
+``lazyqsar/descriptors/cddd.py`` import from here so they always agree on what
+to fetch and where to store it — preventing the two lists from drifting apart.
+
+This module intentionally pulls in nothing heavy (no rdkit / onnxruntime) so it
+can be imported during ``setup`` before those dependencies are installed.
+"""
+
+from pathlib import Path
+
+# Local directory where all checkpoints are stored.
+CHECKPOINT_DIR = Path.home() / ".lazyqsar"
+
+# --- CDDD ---
+# The ONNX encoder plus the ChEMBL nearest-neighbour fallback database
+# (fpsim index + the SMILES list it is indexed against). All three are required
+# at prediction time, so all three must be downloaded by
+# ``lazyqsar setup --descriptors`` — otherwise the missing two are fetched
+# lazily on first predict, which hangs on nodes with restricted internet access.
+CDDD_ENCODER_FILENAME = "cddd_encoder.onnx"
+CDDD_ENCODER_URL = "https://zenodo.org/records/14811055/files/encoder.onnx?download=1"
+
+CDDD_FPSIM_FILENAME = "cddd_encoder_fpsim.h5"
+CDDD_FPSIM_URL = (
+    "https://ersilia-models.s3.eu-central-1.amazonaws.com/"
+    "eos4rw4/model/checkpoints/fpsim2_database_chembl.h5"
+)
+
+CDDD_SMILES_FILENAME = "cddd_encoder_smiles.csv"
+CDDD_SMILES_URL = (
+    "https://ersilia-models.s3.eu-central-1.amazonaws.com/"
+    "eos4rw4/model/checkpoints/fpsim2_database_chembl_smiles.csv"
+)
+
+# (url, filename) pairs for every file the CDDD descriptor needs at runtime.
+CDDD_CHECKPOINTS = [
+    (CDDD_ENCODER_URL, CDDD_ENCODER_FILENAME),
+    (CDDD_FPSIM_URL, CDDD_FPSIM_FILENAME),
+    (CDDD_SMILES_URL, CDDD_SMILES_FILENAME),
+]

--- a/lazyqsar/utils/setup.py
+++ b/lazyqsar/utils/setup.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 from .logging import logger
+from .checkpoints import CHECKPOINT_DIR, CDDD_CHECKPOINTS
 
 _CLAMP_ONNX_URL = "https://ersilia-models.s3.eu-central-1.amazonaws.com/eos3l5f/model/checkpoints/clamp_clip/compound_encoder.onnx"
 
@@ -27,14 +28,21 @@ def download_chemeleon(target_dir: str | None = None):
 
 
 def download_cddd(target_dir: str | None = None):
-    ckpt_dir = Path(target_dir) if target_dir else Path.home() / ".lazyqsar"
-    cddd_path = ckpt_dir / "cddd_encoder.onnx"
-    if not cddd_path.exists():
-        logger.info("Downloading CDDD encoder...")
-        _safe_download(
-            "https://zenodo.org/records/14811055/files/encoder.onnx?download=1",
-            cddd_path,
-        )
+    """Download every checkpoint the CDDD descriptor needs at prediction time.
+
+    This includes the ONNX encoder *and* the ChEMBL nearest-neighbour fallback
+    database (fpsim index + SMILES list). All three must be fetched here so they
+    bake into offline/air-gapped environments; otherwise the two extra files are
+    fetched lazily on first predict, which hangs on nodes with restricted
+    internet access.
+    """
+    ckpt_dir = Path(target_dir) if target_dir else CHECKPOINT_DIR
+    logger.info("Downloading CDDD encoder and ChEMBL nearest-neighbour database...")
+    for url, filename in CDDD_CHECKPOINTS:
+        dest = ckpt_dir / filename
+        if not dest.exists():
+            logger.info(f"Downloading {filename}...")
+            _safe_download(url, dest)
 
 
 def download_clamp(target_dir: str | None = None):


### PR DESCRIPTION
lazyqsar setup --descriptors only fetched cddd_encoder.onnx, but CDDD prediction also needs the ChEMBL nearest-neighbour fallback database (cddd_encoder_fpsim.h5 + cddd_encoder_smiles.csv). Those two were pulled lazily on first predict, which hangs on offline/air-gapped nodes — the failure mode seen with the mtb-model (CDDD-backed endpoints).

Centralize the CDDD URLs and filenames in utils/checkpoints.py as a single source of truth, have download_cddd() fetch all three, and import the same constants in the lazy loader so the two lists can no longer drift apart.